### PR TITLE
PDE-33283 :: chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What problem does this solve, and for which users?
+
+<!-- Who is impacted and what pain point does this address? -->
+
+## How is it solving it?
+
+<!-- Describe your approach and key implementation decisions. -->
+
+## How do I test this?
+
+<!-- Steps to verify this works as expected. -->


### PR DESCRIPTION
## What problem does this solve, and for which users?

Cloud Platform has 115+ repos with no standardized PR template, making it inconsistent what information reviewers get when a PR is opened. This affects both PR authors (not knowing what to include) and reviewers (having to ask for context repeatedly).

## How is it solving it?

Adds a `.github/PULL_REQUEST_TEMPLATE.md` with three focused prompts:
1. What problem does this solve, and for which users?
2. How is it solving it?
3. How do I test this?

This is part of a rollout across all Cloud Platform repos. See pilot: https://github.com/BuiltTechnologies/built-repo-creation/pull/2197

## How do I test this?

Open a new PR in this repo and verify the template pre-fills the description field automatically.